### PR TITLE
Feat: Add company logo to Login and Register pages

### DIFF
--- a/mauzenfan/frontend/src/pages/Login.jsx
+++ b/mauzenfan/frontend/src/pages/Login.jsx
@@ -43,6 +43,15 @@ const Login = () => {
           alignItems: 'center',
         }}
       >
+        <Box
+          component="img"
+          sx={{
+            height: 80, // Adjust as needed
+            mb: 2, // Margin bottom
+          }}
+          alt="MauZenfan Logo"
+          src="/MauZenfan.mu.jpg" // Path relative to the public folder
+        />
         <Typography component="h1" variant="h5">
           Login
         </Typography>

--- a/mauzenfan/frontend/src/pages/Register.jsx
+++ b/mauzenfan/frontend/src/pages/Register.jsx
@@ -12,7 +12,7 @@ import {
   Alert,
   CircularProgress
 } from '@mui/material';
-import PersonAddOutlinedIcon from '@mui/icons-material/PersonAddOutlined';
+// import PersonAddOutlinedIcon from '@mui/icons-material/PersonAddOutlined'; // No longer used
 import { styled } from '@mui/material/styles';
 
 // TypeScript interfaces
@@ -42,15 +42,15 @@ const StyledContainer = styled(Container)(({ theme }) => ({
   alignItems: 'center',
 }));
 
-const StyledAvatar = styled(Box)(({ theme }) => ({
-  margin: theme.spacing(1),
-  backgroundColor: theme.palette.secondary.main,
-  padding: theme.spacing(1.5),
-  borderRadius: '50%',
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-}));
+// const StyledAvatar = styled(Box)(({ theme }) => ({ // No longer used
+//   margin: theme.spacing(1),
+//   backgroundColor: theme.palette.secondary.main,
+//   padding: theme.spacing(1.5),
+//   borderRadius: '50%',
+//   display: 'flex',
+//   justifyContent: 'center',
+//   alignItems: 'center',
+// }));
 
 const StyledForm = styled('form')(({ theme }) => ({
   width: '100%',
@@ -134,9 +134,16 @@ const Register = () => {
 
   return (
     <StyledContainer maxWidth="sm">
-      <StyledAvatar>
-        <PersonAddOutlinedIcon fontSize="large" sx={{ color: 'white' }} />
-      </StyledAvatar>
+      {/* Replacing StyledAvatar with the logo */}
+      <Box
+        component="img"
+        sx={{
+          height: 80, // Adjust as needed, same as Login page for consistency
+          mb: 2, // Margin bottom
+        }}
+        alt="MauZenfan Logo"
+        src="/MauZenfan.mu.jpg" // Path relative to the public folder
+      />
       
       <Typography component="h1" variant="h5">
         Create a SafeKids Account


### PR DESCRIPTION
This commit adds the company logo (`MauZenfan.mu.jpg`) to the Login and Register pages.

- The logo is displayed above the main title on both `Login.jsx` and `Register.jsx`.
- It is referenced from the `/public` directory (i.e., `/MauZenfan.mu.jpg`).
- Material UI `<Box component="img">` is used for rendering the logo, with a consistent height of 80px and bottom margin.
- On the Register page, the logo replaces the previous generic avatar icon.