### PR TITLE
Fix: Resolve TypeScript errors in Register.tsx for MUI Grid

### DIFF
--- a/mauzenfan/frontend/src/pages/Register.tsx
+++ b/mauzenfan/frontend/src/pages/Register.tsx
@@ -157,8 +157,7 @@ const Register = () => {
         )}
         
         <Grid container spacing={2}>
-          // @ts-ignore
-          <Grid item xs={12} sm={6}>
+          <Grid item xs={12} sm={6} component="div">
             <TextField
               autoComplete="given-name"
               name="first_name"
@@ -172,8 +171,7 @@ const Register = () => {
               disabled={loading}
             />
           </Grid>
-          // @ts-ignore
-          <Grid item xs={12} sm={6}>
+          <Grid item xs={12} sm={6} component="div">
             <TextField
               fullWidth
               id="last_name"
@@ -187,8 +185,7 @@ const Register = () => {
               disabled={loading}
             />
           </Grid>
-          // @ts-ignore
-          <Grid item xs={12}>
+          <Grid item xs={12} component="div">
             <TextField
               required
               fullWidth
@@ -203,8 +200,7 @@ const Register = () => {
               disabled={loading}
             />
           </Grid>
-          // @ts-ignore
-          <Grid item xs={12}>
+          <Grid item xs={12} component="div">
             <TextField
               required
               fullWidth
@@ -219,8 +215,7 @@ const Register = () => {
               disabled={loading}
             />
           </Grid>
-          // @ts-ignore
-          <Grid item xs={12} sm={6}>
+          <Grid item xs={12} sm={6} component="div">
             <TextField
               required
               fullWidth
@@ -236,8 +231,7 @@ const Register = () => {
               disabled={loading}
             />
           </Grid>
-          // @ts-ignore
-          <Grid item xs={12} sm={6}>
+          <Grid item xs={12} sm={6} component="div">
             <TextField
               required
               fullWidth
@@ -270,8 +264,7 @@ const Register = () => {
         </SubmitButton>
         
         <Grid container justifyContent="flex-end">
-          // @ts-ignore
-          <Grid item>
+          <Grid item component="div">
             <MuiLink 
               component={Link} 
               to="/login" 


### PR DESCRIPTION
- Ensures `Register.tsx` (renamed from .jsx) is processed by TypeScript.
- Updates `App.jsx` import for `Register.tsx`.
- Fixes `ValidationErrors` indexing type error in `Register.tsx`.
- Modifies `<Grid item ...>` components in `Register.tsx` by adding `component="div"`. This attempts to satisfy the type checker for the `@mui/material@^7.1.2` package, based on overload error messages indicating a missing `component` prop when `item` and responsive props (`xs`, `sm`) are used.

Build verification in the agent environment was unsuccessful due to persistent `npm run build` failures (environment-specific rollbacks). This solution represents the best attempt to fix the reported type errors.