### PR TITLE
Fix: Resolve 500 error in user authentication check

### DIFF
--- a/mauzenfan/apps/api_app/serializers.py
+++ b/mauzenfan/apps/api_app/serializers.py
@@ -132,8 +132,13 @@ class MessageUserSerializer(serializers.ModelSerializer):
         fields = ['id', 'username', 'first_name', 'last_name', 'display_name']
 
     def get_display_name(self, obj):
-        if hasattr(obj, 'messaging_child_profile') and obj.messaging_child_profile:
-            return obj.messaging_child_profile.name
+        # Robustly access messaging_child_profile
+        if hasattr(obj, 'messaging_child_profile'):
+            profile = obj.messaging_child_profile
+            if profile and hasattr(profile, 'name') and profile.name:
+                return profile.name
+
+        # Fallback to full name or username
         full_name = obj.get_full_name()
         return full_name if full_name else obj.username
 

--- a/mauzenfan/frontend/src/context/AuthContext.tsx
+++ b/mauzenfan/frontend/src/context/AuthContext.tsx
@@ -59,7 +59,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     const checkAuth = async () => {
       try {
         // CORRECTED ENDPOINT: Changed to Djoser's actual user endpoint
-        const response = await api.get('/api/auth/users/me/');
+        const response = await api.get('/api/auth/me/'); // Using custom endpoint
         if (response.data) {
           setUser(response.data);
         }
@@ -88,7 +88,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       api.defaults.headers.common['Authorization'] = `Bearer ${access}`;
       
       // Fetch user profile after successful login
-      const userResponse = await api.get('/api/auth/users/me/');
+      const userResponse = await api.get('/api/auth/me/'); // Using custom endpoint
       setUser(userResponse.data);
       return true;
     } catch (err: any) {


### PR DESCRIPTION
- Align frontend API call in AuthContext.tsx to use the backend's custom /api/auth/me/ endpoint instead of /api/auth/users/me/.
- Make MessageUserSerializer.get_display_name more robust by adding checks for 'messaging_child_profile' and its 'name' attribute to prevent AttributeErrors.